### PR TITLE
config: add PreferedTransports

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -213,9 +213,6 @@ func (nvACfg *NonvotingAuthority) New(l *log.Backend, pCfg *proxy.Config) (pki.C
 }
 
 func (nvACfg *NonvotingAuthority) validate() error {
-	if err := utils.EnsureAddrIPPort(nvACfg.Address); err != nil {
-		return fmt.Errorf("Address '%v' is invalid: %v", nvACfg.Address, err)
-	}
 	if nvACfg.PublicKey == nil {
 		return fmt.Errorf("PublicKey is missing")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -310,6 +310,10 @@ func (mCfg *Management) validate() error {
 
 // UpstreamProxy is the mailproxy outgoing connection proxy configuration.
 type UpstreamProxy struct {
+	// PreferedTransports is a list of the transports will be used to make
+	// outgoing network connections, with the most prefered first.
+	PreferedTransports []pki.Transport
+
 	// Type is the proxy type (Eg: "none"," socks5").
 	Type string
 
@@ -330,11 +334,12 @@ func (uCfg *UpstreamProxy) toProxyConfig() (*proxy.Config, error) {
 	// This is kind of dumb, but this is the cleanest way I can think of
 	// doing this.
 	cfg := &proxy.Config{
-		Type:     uCfg.Type,
-		Network:  uCfg.Network,
-		Address:  uCfg.Address,
-		User:     uCfg.User,
-		Password: uCfg.Password,
+		PreferedTransports: uCfg.PreferedTransports,
+		Type:               uCfg.Type,
+		Network:            uCfg.Network,
+		Address:            uCfg.Address,
+		User:               uCfg.User,
+		Password:           uCfg.Password,
 	}
 	if err := cfg.FixupAndValidate(); err != nil {
 		return nil, err

--- a/internal/account/account.go
+++ b/internal/account/account.go
@@ -270,6 +270,7 @@ func (s *Store) newAccount(id string, cfg *config.Account, pCfg *proxy.Config) (
 		DialContextFn:       pCfg.ToDialContext(id),
 		MessagePollInterval: time.Duration(a.s.cfg.Debug.PollingInterval) * time.Second,
 		EnableTimeSync:      false, // Be explicit about it.
+		PreferedTransports:  pCfg.PreferedTransports,
 	}
 
 	var err error

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/katzenpost/core/pki"
 	"github.com/katzenpost/core/utils"
 	"golang.org/x/net/proxy"
 )
@@ -47,6 +48,10 @@ var torSocks5ProcessIsolation string
 
 // Config is the proxy configuration.
 type Config struct {
+	// PreferedTransports is a list of the transports will be used to make
+	// outgoing network connections, with the most prefered first.
+	PreferedTransports []pki.Transport
+
 	// Type is the proxy type (Eg: "none"," socks5", "tor+socks5").
 	Type string
 


### PR DESCRIPTION
This config option gives us better Tor support because
we can choose to connect using the onion address rather
than the other addresses advertised by Providers.