### PR TITLE
Add automatic recipient key retrieval.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,14 +41,15 @@ import (
 )
 
 const (
-	defaultPOP3Addr            = "127.0.0.1:2524"
-	defaultSMTPAddr            = "127.0.0.1:2525"
-	defaultLogLevel            = "NOTICE"
-	defaultManagementSocket    = "management_sock"
-	defaultBounceQueueLifetime = 432000 // 5 days.
-	defaultUrgentQueueLifetime = 3600   // 1 hour.
-	defaultPollingInterval     = 30     // 30 seconds.
-	defaultRetransmitSlack     = 300    // 5 minutes.
+	defaultPOP3Addr             = "127.0.0.1:2524"
+	defaultSMTPAddr             = "127.0.0.1:2525"
+	defaultLogLevel             = "NOTICE"
+	defaultManagementSocket     = "management_sock"
+	defaultBounceQueueLifetime  = 432000 // 5 days.
+	defaultUrgentQueueLifetime  = 3600   // 1 hour.
+	defaultPollingInterval      = 30     // 30 seconds.
+	defaultRetransmitSlack      = 300    // 5 minutes.
+	defaultInsecureKeyDiscovery = false  // disabled by default.
 )
 
 var defaultLogging = Logging{
@@ -247,6 +248,11 @@ type Account struct {
 
 	// StorageKey is the optional per-account database encryption key.
 	StorageKey *ecdh.PrivateKey `toml:"-"`
+
+	// InsecureKeyDiscovery enables automatic fetching of recipient keys.
+	// This option is disabled by default as mailproxy provides no UX for
+	// verifying keys.
+	InsecureKeyDiscovery bool
 }
 
 func (accCfg *Account) fixup(cfg *Config) error {
@@ -259,7 +265,9 @@ func (accCfg *Account) fixup(cfg *Config) error {
 	if err != nil {
 		return err
 	}
-
+	if !accCfg.InsecureKeyDiscovery {
+		accCfg.InsecureKeyDiscovery = defaultInsecureKeyDiscovery
+	}
 	accCfg.Provider, err = idna.Lookup.ToASCII(accCfg.Provider)
 	return err
 }

--- a/internal/account/account.go
+++ b/internal/account/account.go
@@ -95,6 +95,10 @@ func (a *Account) doDeref() {
 	}
 }
 
+func (a *Account) GetID() string {
+	return a.id
+}
+
 func (a *Account) doCleanup() {
 	a.Halt()
 
@@ -217,6 +221,10 @@ func (a *Account) IsConnected() bool {
 	return a.isConnected
 }
 
+func (a *Account) InsecureKeyDiscovery() bool {
+	return a.clientCfg.InsecureKeyDiscovery
+}
+
 func (s *Store) newAccount(id string, cfg *config.Account, pCfg *proxy.Config) (*Account, error) {
 	a := new(Account)
 	a.s = s
@@ -256,21 +264,22 @@ func (s *Store) newAccount(id string, cfg *config.Account, pCfg *proxy.Config) (
 
 	// Configure and bring up the minclient instance.
 	a.clientCfg = &minclient.ClientConfig{
-		User:                cfg.User,
-		Provider:            cfg.Provider,
-		ProviderKeyPin:      cfg.ProviderKeyPin,
-		LinkKey:             a.linkKey,
-		LogBackend:          s.logBackend,
-		PKIClient:           nil, // Set later.
-		OnConnFn:            a.onConn,
-		OnEmptyFn:           a.onEmpty,
-		OnMessageFn:         a.onMessage,
-		OnACKFn:             a.onSURB, // Defined in send.go.
-		OnDocumentFn:        a.onDocument,
-		DialContextFn:       pCfg.ToDialContext(id),
-		MessagePollInterval: time.Duration(a.s.cfg.Debug.PollingInterval) * time.Second,
-		EnableTimeSync:      false, // Be explicit about it.
-		PreferedTransports:  pCfg.PreferedTransports,
+		User:                 cfg.User,
+		Provider:             cfg.Provider,
+		ProviderKeyPin:       cfg.ProviderKeyPin,
+		LinkKey:              a.linkKey,
+		LogBackend:           s.logBackend,
+		PKIClient:            nil, // Set later.
+		OnConnFn:             a.onConn,
+		OnEmptyFn:            a.onEmpty,
+		OnMessageFn:          a.onMessage,
+		OnACKFn:              a.onSURB, // Defined in send.go.
+		OnDocumentFn:         a.onDocument,
+		DialContextFn:        pCfg.ToDialContext(id),
+		MessagePollInterval:  time.Duration(a.s.cfg.Debug.PollingInterval) * time.Second,
+		EnableTimeSync:       false, // Be explicit about it.
+		PreferedTransports:   pCfg.PreferedTransports,
+		InsecureKeyDiscovery: cfg.InsecureKeyDiscovery,
 	}
 
 	var err error


### PR DESCRIPTION
This adds the InsecureKeyDiscovery option to account.Config, which is
configured on a per-account basis. Messages received by mailproxy
without a known recipient are enqueued in memory while awaiting a
keyserver request. If no request is received, they are purged and a
message is returned via the users inbox. If the kaetzchen keyserver
responds that there is no key for the user, a message is similarly
returned to the user.