### PR TITLE
Make SendMessage optionally send insecure message

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -47,13 +47,13 @@ type Proxy struct {
 	logBackend *log.Backend
 	log        *logging.Logger
 
-	accounts     *account.Store
-	authorities  *authority.Store
-	recipients   *recipient.Store
-	popListener  *popListener
-	smtpListener *smtpListener
+	accounts      *account.Store
+	authorities   *authority.Store
+	recipients    *recipient.Store
+	popListener   *popListener
+	smtpListener  *smtpListener
 	eventListener *eventListener
-	management   *thwack.Server
+	management    *thwack.Server
 
 	fatalErrCh chan error
 	eventCh    channels.Channel
@@ -239,22 +239,22 @@ func New(cfg *config.Config) (*Proxy, error) {
 		return nil, ErrGenerateOnly
 	}
 
-	// Bring the POP3 interface online.
+	// Bring the EventSink listener online.
+	p.log.Debug("Starting EventSink listener.")
+	p.eventListener = newEventListener(p)
+
 	if !p.cfg.Proxy.NoLaunchListeners {
+		// Bring the POP3 interface online.
 		if p.popListener, err = newPOPListener(p); err != nil {
 			p.log.Errorf("Failed to start POP3 listener: %v", err)
 			return nil, err
 		}
-
-		// Bring the EventSink listener online.
-		p.eventListener = newEventListener(p)
 
 		// Bring the SMTP interface online.
 		if p.smtpListener, err = newSMTPListener(p); err != nil {
 			p.log.Errorf("Failed to start SMTP listener: %v", err)
 			return nil, err
 		}
-
 	} else {
 		p.log.Debugf("Skipping POP3/SMTP listener initialization.")
 	}

--- a/smtp_listener.go
+++ b/smtp_listener.go
@@ -51,7 +51,6 @@ type smtpListener struct {
 	log *logging.Logger
 
 	connID uint64
-
 }
 
 func (l *smtpListener) Halt() {
@@ -105,11 +104,11 @@ func (e *enqueueLater) sendIMFFailure(account *account.Account, err error) {
 type eventListener struct {
 	worker.Worker
 
-	p *Proxy
+	p   *Proxy
 	log *logging.Logger
 
 	enqueueLaterCh chan *enqueueLater
-	sendLater map[string]*enqueueLater
+	sendLater      map[string]*enqueueLater
 }
 
 func (l *eventListener) onKaetzchenReply(e *event.KaetzchenReplyEvent) {
@@ -155,7 +154,7 @@ func (l *eventListener) onKaetzchenReply(e *event.KaetzchenReplyEvent) {
 	}
 	acc.StoreReport(report)
 	rcpt, err = l.p.toAccountRecipient(r.rID)
-	if  err != nil {
+	if err != nil {
 		l.log.Warningf("Failed to lookup freshly discovered account: %v", err)
 		return
 	}
@@ -224,7 +223,7 @@ func (l *smtpListener) onNewConn(conn net.Conn) error {
 	return nil
 }
 
-func newEventListener(p *Proxy) (*eventListener) {
+func newEventListener(p *Proxy) *eventListener {
 	l := new(eventListener)
 	l.p = p
 	l.log = p.logBackend.GetLogger("listener/EventSink")


### PR DESCRIPTION
this feature is turned off by default. if it's turned on then SendMessage can send an insecure message where a key lookup is automatically done and then the key is used for e2e encryption of the message.