### PR TITLE
Fix mailproxy daemon by always enabling EventSink

### DIFF
--- a/api.go
+++ b/api.go
@@ -29,7 +29,6 @@ import (
 	"github.com/katzenpost/mailproxy/event"
 	"github.com/katzenpost/mailproxy/internal/account"
 	"github.com/katzenpost/mailproxy/internal/imf"
-	"gopkg.in/eapache/channels.v1"
 )
 
 var (
@@ -298,10 +297,6 @@ func (p *Proxy) eventSinkWorker() {
 }
 
 func (p *Proxy) initializeEventSink() {
-	if p.cfg.Proxy.EnableEventSink {
-		p.EventSink = make(chan event.Event)
-		p.Go(p.eventSinkWorker)
-	} else {
-		channels.Pipe(p.eventCh, channels.NewBlackHole())
-	}
+	p.EventSink = make(chan event.Event)
+	p.Go(p.eventSinkWorker)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -78,9 +78,6 @@ type Proxy struct {
 	// useful if you are using mailproxy as a library rather than a
 	// stand-alone process.
 	NoLaunchListeners bool
-
-	// EnableEventSink enables sending events to a channel that API users can read events from.
-	EnableEventSink bool
 }
 
 func (pCfg *Proxy) applyDefaults() {


### PR DESCRIPTION
I think this is the best (easy) fix for now.
Some further explanation and recap of IRC:

Mailproxy is used as a daemon in itself and can be used as a library like the k9mail port and some tools do.
For this the EventSink was supposed to be optional to enable use as an api.
Currently this is broken, since the daemon also requires EventSink to be enabled.
I therefore removed the option altogether and it is always enabled.

If it is desirable to be able to turn the external api off, smtp_listener.go needs changes, such that it doesn't rely on EventSink.

Currently mailproxy will send a keyserver lookup to the kaetzchen service and wait for a reply.
That reply will be put into the EventSink, which will go nowhere as shown by the removed line:
`channels.Pipe(p.eventCh, channels.NewBlackHole())`

The worker in smtp_listener.go will never call `onKaetzchenReply`, which does most of the actual messaging part like saving the keyserver reply and sending out the message:
```
case evt := <-l.p.EventSink:
             switch e := evt.(type) {
             case *event.KaetzchenReplyEvent:
                 l.onKaetzchenReply(e)
             default:
             }
         }

```